### PR TITLE
fix pthread_cancel of blocked threads

### DIFF
--- a/src/ert/libc/ertfutex.c
+++ b/src/ert/libc/ertfutex.c
@@ -137,7 +137,7 @@ static void _list_remove(const info_t* info)
     }
 }
 
-static bool _list_remove_tcs(uint64_t tcs)
+static void _list_remove_tcs(uint64_t tcs)
 {
     assert(tcs);
 
@@ -148,12 +148,10 @@ static bool _list_remove_tcs(uint64_t tcs)
         if (p->tcs == tcs)
         {
             _list_unlink(p, prev);
-            return true;
+            return;
         }
         prev = p;
     }
-
-    return false;
 }
 
 static void _list_replace(const int* uaddr, const int* uaddr2)
@@ -285,9 +283,8 @@ void ert_futex_wake_tcs(const void* tcs)
 {
     const uint64_t t = (uint64_t)tcs;
     oe_spin_lock(&_lock);
-    const bool exist = _list_remove_tcs(t);
+    _list_remove_tcs(t);
     oe_spin_unlock(&_lock);
-    if (exist &&
-        oe_sgx_thread_wake_multiple_ocall(oe_get_enclave(), &t, 1) != OE_OK)
+    if (oe_sgx_thread_wake_multiple_ocall(oe_get_enclave(), &t, 1) != OE_OK)
         abort();
 }

--- a/src/tests/pthread_create/enc.cpp
+++ b/src/tests/pthread_create/enc.cpp
@@ -363,20 +363,29 @@ void test_ecall()
 {
     OE_TEST(oe_load_module_host_epoll() == OE_OK);
 
-    _test_invalid_arguments();
-    _test_created_thread_runs_concurrently();
-    _test_join_retval_nullptr();
-    _test_join_before_thread_ends();
-    _test_join_after_thread_ends();
-    _test_multiple_threads();
-    _test_detach();
-    _test_detached();
-    _test_exit();
-    _test_cancel();
-    _test_cancel_blocked();
-    _test_cancel_epoll();
-    _test_attr();
-    _test_mutexattr();
+    // slow tests (that sleep)
+    for (int i = 0; i < 3; ++i)
+    {
+        _test_join_before_thread_ends();
+        _test_join_after_thread_ends();
+        _test_multiple_threads();
+        _test_detach();
+        _test_detached();
+        _test_cancel_epoll();
+    }
+
+    // fast tests
+    for (int i = 0; i < 200; ++i)
+    {
+        _test_invalid_arguments();
+        _test_created_thread_runs_concurrently();
+        _test_join_retval_nullptr();
+        _test_exit();
+        _test_cancel();
+        _test_cancel_blocked();
+        _test_attr();
+        _test_mutexattr();
+    }
 }
 
 OE_SET_ENCLAVE_SGX(


### PR DESCRIPTION
was broken if pthread_cancel happened before the blocking call