### PR TITLE
properly fix pthread_cancel of blocked threads

### DIFF
--- a/src/ert/libc/ertfutex.c
+++ b/src/ert/libc/ertfutex.c
@@ -279,12 +279,16 @@ int ert_futex(
     abort();
 }
 
+void ert_futex_remove_tcs(const void* tcs)
+{
+    oe_spin_lock(&_lock);
+    _list_remove_tcs(tcs);
+    oe_spin_unlock(&_lock);
+}
+
 void ert_futex_wake_tcs(const void* tcs)
 {
-    const uint64_t t = (uint64_t)tcs;
-    oe_spin_lock(&_lock);
-    _list_remove_tcs(t);
-    oe_spin_unlock(&_lock);
-    if (oe_sgx_thread_wake_multiple_ocall(oe_get_enclave(), &t, 1) != OE_OK)
+    if (oe_sgx_thread_wake_multiple_ocall(
+            oe_get_enclave(), (uint64_t*)&tcs, 1) != OE_OK)
         abort();
 }

--- a/src/ert/libc/ertfutex.h
+++ b/src/ert/libc/ertfutex.h
@@ -15,6 +15,7 @@ int ert_futex(
     const struct timespec* timeout,
     const int* uaddr2);
 
+void ert_futex_remove_tcs(const void* tcs);
 void ert_futex_wake_tcs(const void* tcs);
 
 OE_EXTERNC_END

--- a/src/ertlibc/pthread.cpp
+++ b/src/ertlibc/pthread.cpp
@@ -171,7 +171,12 @@ void pthread_testcancel()
 {
     ert_thread_t* const self = _to_ert_thread(pthread_self());
     if (__atomic_load_n(&self->cancel, __ATOMIC_SEQ_CST) && self->cancelable)
+    {
+        // thread may be woken, so clean up futex
+        ert_futex_remove_tcs(self->tcs);
+
         pthread_exit(PTHREAD_CANCELED);
+    }
 }
 
 void ert_create_thread_ecall()


### PR DESCRIPTION
let the canceled thread clean up its futex itself to prevent a race