### PR TITLE
exclude ttls headers from interface

### DIFF
--- a/src/tools/erthost/CMakeLists.txt
+++ b/src/tools/erthost/CMakeLists.txt
@@ -30,10 +30,9 @@ target_link_libraries(
 add_library(ertttls ttls.cpp)
 target_link_libraries(
   ertttls
-  PRIVATE $<BUILD_INTERFACE:oe_includes>
+  PRIVATE $<BUILD_INTERFACE:oe_includes> ttls
   INTERFACE openenclave::oehostsock openenclave::mbedtls openenclave::mbedx509
-            openenclave::mbedcrypto
-  PUBLIC ttls)
+            openenclave::mbedcrypto)
 set_property(TARGET ertttls PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 install(


### PR DESCRIPTION
fix https://github.com/edgelesssys/share/runs/2331896685
@3u13r I think that shouldn't break anything because AFAIK the actual lib is still part of the public interface, but only the headers are not.