### PR TITLE
AB#700 allow mounting memfs with different sources

### DIFF
--- a/src/ert/include/openenclave/ert.h
+++ b/src/ert/include/openenclave/ert.h
@@ -58,7 +58,7 @@ void ert_init_ttls(const char* config);
 
 typedef struct _oe_customfs
 {
-    uint8_t reserved[4248];
+    uint8_t reserved[8344];
     int (*open)(
         void* context,
         const char* pathname,

--- a/src/tests/memfs/enc.cpp
+++ b/src/tests/memfs/enc.cpp
@@ -13,10 +13,13 @@ using namespace ert;
 
 void test_ecall()
 {
+    const auto myfs = "myfs";
+
+    // run tests from OE
     for (int i = 0; i < 3; ++i) // ensure Memfs can be un-/reloaded
     {
-        const Memfs memfs("myfs");
-        OE_TEST(mount("/", "/", "myfs", 0, nullptr) == 0);
+        const Memfs memfs(myfs);
+        OE_TEST(mount("/", "/", myfs, 0, nullptr) == 0);
         fd_file_system fs;
         test_common(fs, "");
         test_pio(fs, "");
@@ -24,6 +27,32 @@ void test_ecall()
         test_common(sfs, "");
         test_pio(fs, "");
         OE_TEST(umount("/") == 0);
+    }
+
+    // test different mount sources
+    {
+        const Memfs memfs(myfs);
+
+        OE_TEST(mount("/", "/", myfs, 0, nullptr) == 0);
+        OE_TEST(mkdir("/s0", 0) == 0);
+        OE_TEST(mkdir("/s1", 0) == 0);
+        OE_TEST(umount("/") == 0);
+
+        OE_TEST(mount("/s0", "/t0", myfs, 0, nullptr) == 0);
+        OE_TEST(mount("/s1", "/t1", myfs, 0, nullptr) == 0);
+        OE_TEST(mount("/s0", "/t0a", myfs, 0, nullptr) == 0);
+
+        FILE* f = fopen("/t0/foo", "w");
+        OE_TEST(f);
+        OE_TEST(fclose(f) == 0);
+
+        // expect file exists on other mount point with same source
+        f = fopen("/t0a/foo", "r");
+        OE_TEST(f);
+        OE_TEST(fclose(f) == 0);
+
+        // expect file does not exist on a mount point with different source
+        OE_TEST(!fopen("/t1/foo", "r"));
     }
 }
 


### PR DESCRIPTION
The new code in customfs.c is copied from OE's hostfs.c. Thus, it probably doesn't need to be reviewed in detail. I decided to keep names like make_host_path to keep the diff between the two files small.