### PR TITLE
AB#906: Use different client and server port for internal socket

### DIFF
--- a/3rdparty/openenclave/ert.patch
+++ b/3rdparty/openenclave/ert.patch
@@ -2576,7 +2576,7 @@ index 71cc46369..5cd14e2b4 100644
              [in, out, count=bufflen] char* buffer,
              size_t bufflen);
 diff --git a/tests/syscall/socket/enc/enc.c b/tests/syscall/socket/enc/enc.c
-index 73e81ccf0..e89e4f02a 100644
+index 73e81ccf0..6bc91a008 100644
 --- a/tests/syscall/socket/enc/enc.c
 +++ b/tests/syscall/socket/enc/enc.c
 @@ -39,7 +39,7 @@ static void _initialize()
@@ -2597,17 +2597,7 @@ index 73e81ccf0..e89e4f02a 100644
      serv_addr.sin_port = oe_htons(1492);
  
      printf("socket fd = %d\n", sockfd);
-@@ -85,7 +85,8 @@ int ecall_run_client(char* recv_buff, ssize_t* recv_buff_len)
-         oe_getpeername(
-             sockfd, (struct oe_sockaddr*)&peer_addr, &peer_addr_len) == 0);
-     OE_TEST(peer_addr_len == sizeof(serv_addr));
--    OE_TEST(memcmp(&serv_addr, &peer_addr, peer_addr_len) == 0);
-+    // OE_TEST(memcmp(&serv_addr, &peer_addr, peer_addr_len) == 0);
-+    OE_TEST(serv_addr.sin_addr.s_addr == peer_addr.sin_addr.s_addr);
- 
-     int sockdup = oe_dup(sockfd);
- 
-@@ -117,7 +118,7 @@ int ecall_run_client(char* recv_buff, ssize_t* recv_buff_len)
+@@ -117,7 +117,7 @@ int ecall_run_client(char* recv_buff, ssize_t* recv_buff_len)
  /* This server acts as an echo server.  It accepts a connection,
   * receives messages, and echoes them back.
   */
@@ -2616,7 +2606,7 @@ index 73e81ccf0..e89e4f02a 100644
  {
      _initialize();
      int status = OE_FAILURE;
-@@ -136,8 +137,8 @@ int ecall_run_server()
+@@ -136,8 +136,8 @@ int ecall_run_server()
      }
  
      serv_addr.sin_family = OE_AF_INET;
@@ -2627,7 +2617,7 @@ index 73e81ccf0..e89e4f02a 100644
  
      printf("enclave: binding\n");
      rtn = oe_bind(listenfd, (struct oe_sockaddr*)&serv_addr, sizeof(serv_addr));
-@@ -172,7 +173,7 @@ int ecall_run_server()
+@@ -172,7 +172,7 @@ int ecall_run_server()
          OE_TEST(peer_addr_len == sizeof(peer_addr));
          OE_TEST(peer_addr.sin_family == OE_AF_INET);
          OE_TEST(oe_ntohs(peer_addr.sin_port) >= 1024);
@@ -2636,7 +2626,7 @@ index 73e81ccf0..e89e4f02a 100644
  
          if (connfd >= 0)
          {
-@@ -225,4 +226,4 @@ OE_SET_ENCLAVE_SGX(
+@@ -225,4 +225,4 @@ OE_SET_ENCLAVE_SGX(
      true, /* Debug */
      256,  /* NumHeapPages */
      256,  /* NumStackPages */

--- a/src/ert/enclave/internalsock.c
+++ b/src/ert/enclave/internalsock.c
@@ -114,10 +114,10 @@ static oe_socket_ops_t _sock_ops = {
     .connect = _stub_connect,
 };
 
-static const uint32_t _ipaddr = 0xFF000001;         // 255.0.0.1
-static const uint16_t _client_port = 1024;          // >= 1024 to satisfy test
-static const uint16_t _server_port_fallback = 1025; // only used as fallback
-static internalsock_boundsock_t* _bound_sockets;    // linked list
+static const uint32_t _ipaddr = 0xFF000001;      // 255.0.0.1
+static const uint16_t _client_port = 1024;       // >= 1024 to satisfy test
+static const uint16_t _server_port = 1025;       // only used as fallback
+static internalsock_boundsock_t* _bound_sockets; // linked list
 static oe_spinlock_t _lock = OE_SPINLOCK_INITIALIZER;
 
 typedef struct
@@ -666,7 +666,7 @@ static oe_fd_t* _sock_accept(
         {
             addr_in->sin_family = OE_AF_INET;
             addr_in->sin_addr.s_addr = oe_htonl(_ipaddr);
-            addr_in->sin_port = oe_htons(_client_port);
+            addr_in->sin_port = oe_htons(_server_port);
         }
         *addrlen = sizeof *addr_in;
     }
@@ -817,7 +817,7 @@ static int _sock_getpeername(
             ad.sin_port = oe_htons(sock->internal.boundsock->port);
         else if (sock->internal.connection)
             // use hard-coded value as fallback
-            ad.sin_port = oe_htons(_server_port_fallback);
+            ad.sin_port = oe_htons(_server_port);
 
         oe_socklen_t len = *addrlen;
         if (len > sizeof ad)

--- a/src/ert/include/openenclave/internal/ert/sock.h
+++ b/src/ert/include/openenclave/internal/ert/sock.h
@@ -63,7 +63,8 @@ typedef struct _sock
 
         internalsock_connection_side_t side; // client or server
         int flags;                           // set by fcntl()
-        bool event_notified; // state of the eventfd referred by host_fd
+        bool event_notified;  // state of the eventfd referred by host_fd
+        uint16_t server_port; // set during connect()
     } internal;
 } sock_t;
 


### PR DESCRIPTION
Client and server need to have different ports, otherwise
Go and other application would try to apply "self connect"
flows which are undesirable, e.g.
https://golang.org/src/net/tcpsock_posix.go#L64

This implements proper port selection for the client->server connection.
However, the other side still uses a hardcoded value... But that should
be sufficient for our use cases, so far at least...

Signed-off-by: Nils Hanke <nils.hanke@rub.de>