### PR TITLE
AB#906: Make internal socket ignore unsupported flags + support for non-blocking recvfrom flag

### DIFF
--- a/src/ert/enclave/internalsock.c
+++ b/src/ert/enclave/internalsock.c
@@ -821,7 +821,11 @@ static ssize_t _sock_recvfrom(
     if (!buf)
         OE_RAISE_ERRNO(OE_EINVAL);
 
-    if (flags || src_addr || addrlen)
+    if (flags)
+        // not supported yet, will ignore
+        OE_TRACE_WARNING("recvfrom: unsupported flags: %d", flags);
+
+    if (src_addr || addrlen)
         OE_RAISE_ERRNO(OE_ENOSYS); // not supported yet
 
     if (count > OE_SSIZE_MAX)
@@ -883,7 +887,8 @@ static ssize_t _sock_sendto(
         OE_RAISE_ERRNO(OE_EISCONN);
 
     if (flags)
-        OE_RAISE_ERRNO(OE_ENOSYS); // not supported yet
+        // not supported yet, will ignore
+        OE_TRACE_WARNING("sendto: unsupported flags: %d", flags);
 
     for (;;)
     {


### PR DESCRIPTION
Not sure if this actually works as intended in regards to blocking/non-blocking modes, but seems to work without any major issues so far at least.