### PR TITLE
readlink

### DIFF
--- a/src/ertlibc/CMakeLists.txt
+++ b/src/ertlibc/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
   stubs.cpp
   syscall.cpp
   time.cpp
+  unistd.cpp
   util.cpp
   __vasprintf_chk.c)
 

--- a/src/ertlibc/syscall.cpp
+++ b/src/ertlibc/syscall.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "syscall.h"
+#include <fcntl.h>
 #include <openenclave/enclave.h>
 #include <openenclave/internal/malloc.h>
 #include <openenclave/internal/trace.h>
@@ -34,6 +35,19 @@ long ert_syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
                     static_cast<int>(x1), reinterpret_cast<timespec*>(x2));
             case SYS_gettid:
                 return ert_thread_self()->tid;
+
+            case SYS_readlink:
+                return sc::readlink(
+                    reinterpret_cast<char*>(x1), // pathname
+                    reinterpret_cast<char*>(x2), // buf
+                    x3);                         // bufsiz
+            case SYS_readlinkat:
+                return static_cast<int>(x1) == AT_FDCWD
+                           ? sc::readlink(
+                                 reinterpret_cast<char*>(x2), // pathname
+                                 reinterpret_cast<char*>(x3), // buf
+                                 x4)                          // bufsiz
+                           : -EBADF;
 
             case SYS_exit_group:
                 sc::exit_group(static_cast<int>(x1));

--- a/src/ertlibc/syscalls.h
+++ b/src/ertlibc/syscalls.h
@@ -14,6 +14,7 @@ namespace ert::sc
 {
 int clock_gettime(clockid_t clk_id, struct timespec* tp);
 void exit_group(int status);
+ssize_t readlink(const char* pathname, char* buf, size_t bufsiz);
 void rt_sigaction(int signum, const k_sigaction* act, k_sigaction* oldact);
 int sched_getaffinity(pid_t pid, size_t size, cpu_set_t* set);
 void sigaltstack(const stack_t* ss, stack_t* oss);

--- a/src/ertlibc/unistd.cpp
+++ b/src/ertlibc/unistd.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Edgeless Systems GmbH.
+// Licensed under the MIT License.
+
+#include <unistd.h>
+#include <cerrno>
+#include "syscalls.h"
+
+using namespace ert;
+
+ssize_t sc::readlink(const char* pathname, char* /*buf*/, size_t /*bufsiz*/)
+{
+    if (access(pathname, F_OK) != 0)
+        return -errno;
+    // symlinks not supported, so this must be a regular file
+    return -EINVAL;
+}


### PR DESCRIPTION
We don't support symlinks, but readlink should behave as if the file is not a symlink instead of returning ENOSYS.