### PR TITLE
reduce log level of detail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ ExternalProject_Add(
              -DBUILD_TESTS=${BUILD_TESTS}
              -DOESRCDIR=${OESRCDIR}
              -DOEBUILDDIR=${OEBUILDDIR}
+             -DOE_VERSION=${OE_VERSION}
   BUILD_ALWAYS ON
   USES_TERMINAL_BUILD ON)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Now you are ready to build applications with Edgeless RT! To start, check out th
 Also see the [C API documentation](https://edgelesssys.github.io/edgelessrt) and/or the [Go API documentation](https://pkg.go.dev/github.com/edgelesssys/ertgolib).
 
 ## Debug
+
+### Logging
+Set the environment variable `OE_LOG_LEVEL` to `NONE`, `FATAL`, `ERROR` (default), `WARNING`, `INFO`, or `VERBOSE` to increase or decrease the log level. Set `OE_LOG_DETAILED=1` to enrich the log output with timestamps, thread ids, and stacktrace-like error propagations.
+
+### gdb
 ![debugging with vscode](docs/go_debugging_vscode.gif)
 
 You can use Open Enclave's `oegdb` to debug enclave code built with Edgeless RT. `oegdb` is automatically installed with Edgeless RT. It also supports Go enclaves.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_compile_options(-Wall -Wextra -Werror -Wno-missing-field-initializers)
 if (CMAKE_C_COMPILER_ID MATCHES GNU)
   add_compile_options(-fno-builtin)
 endif ()
+add_compile_definitions(OE_VERSION="${OE_VERSION}")
 
 include(GNUInstallDirs)
 

--- a/src/tools/erthost/erthost.cpp
+++ b/src/tools/erthost/erthost.cpp
@@ -227,6 +227,8 @@ static void _log(
 
 int main(int argc, char* argv[], char* envp[])
 {
+    OE_TRACE_INFO("erthost v" OE_VERSION);
+
     if (argc < 2)
     {
         cout << "Usage: " << argv[0]
@@ -238,8 +240,18 @@ int main(int argc, char* argv[], char* envp[])
     const char* const env_simulation = getenv("OE_SIMULATION");
     const bool simulation = env_simulation && *env_simulation == '1';
 
+    // Configure detailed logging. Prefer OE_LOG_DETAILED value. If not set,
+    // enable detailed logging for verbose level.
+    bool log_detailed = false;
     const char* const env_log_detailed = getenv("OE_LOG_DETAILED");
-    if (!env_log_detailed || *env_log_detailed != '1')
+    if (env_log_detailed && *env_log_detailed)
+    {
+        if (*env_log_detailed == '1')
+            log_detailed = true;
+    }
+    else if (oe_get_current_logging_level() >= OE_LOG_LEVEL_VERBOSE)
+        log_detailed = true;
+    if (!log_detailed)
         oe_log_set_callback(nullptr, _log);
 
     try


### PR DESCRIPTION
reduce
```
2021-07-25T14:35:05+0000.628647Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed::OE_UNSUPPORTED [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/core/sgx/report.c:sgx_create_report:131]
2021-07-25T14:35:05+0000.628665Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed::OE_UNSUPPORTED [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/core/sgx/report.c:_get_local_report:189]
2021-07-25T14:35:05+0000.628681Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed::OE_UNSUPPORTED [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/core/sgx/report.c:oe_get_remote_report:294]
2021-07-25T14:35:05+0000.628694Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed::OE_UNSUPPORTED [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/core/sgx/report.c:_oe_get_report_internal:388]
2021-07-25T14:35:05+0000.628707Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed::OE_UNSUPPORTED [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/core/sgx/report.c:oe_get_report_v2_internal:443]
2021-07-25T14:35:05+0000.628721Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed:SGX Plugin _get_report(): failed to get ecdsa report. OE_UNSUPPORTED (oe_result_t=OE_UNSUPPORTED) [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/sgx/attester.c:_get_report:320]
2021-07-25T14:35:05+0000.628732Z [(E)ERROR] tid(0x7fbd6fc94700) | enclave.signed::OE_UNSUPPORTED [/home/tho/edgelessrt/build/3rdparty/openenclave/openenclave-src/enclave/sgx/report.c:oe_get_report_v2:192]
```
to
```
ERROR: :OE_UNSUPPORTED [openenclave-src/enclave/core/sgx/report.c:sgx_create_report:131]
ERROR: SGX Plugin _get_report(): failed to get ecdsa report. OE_UNSUPPORTED (oe_result_t=OE_UNSUPPORTED) [openenclave-src/enclave/sgx/attester.c:_get_report:320]
```
related to edgelesssys/marblerun#219