### PR TITLE
Convert CRL from hex to DER

### DIFF
--- a/3rdparty/openenclave/ert.patch
+++ b/3rdparty/openenclave/ert.patch
@@ -138,6 +138,57 @@ index df4adc056..2c04586cf 100644
  set(CMAKE_CXX_STANDARD_REQUIRED ON)
  # Do not use, for example, `-std=gnu++14`.
  set(CMAKE_CXX_EXTENSIONS OFF)
+diff --git a/common/sgx/collateral.c b/common/sgx/collateral.c
+index f4d9fcc76..81f4f22aa 100644
+--- a/common/sgx/collateral.c
++++ b/common/sgx/collateral.c
+@@ -326,18 +326,44 @@ oe_result_t oe_validate_revocation_list(
+                 "Failed to read CRL. %s",
+                 oe_result_str(result));
+         }
+-        // Otherwise, CRL should have v3 structure which is DER encoded
++        // Otherwise, CRL should have v3 or v3.1 structure
++        //    v3 is hex encoded DER
++        //    v3.1 is DER
+         else
+         {
+             size_t der_data_size = sgx_endorsements->items[i].size;
+             if (der_data_size == 0)
+                 OE_RAISE(OE_INVALID_PARAMETER);
+
+-            // If DER CRL buffer has null terminator, need to remove it before
++            // If CRL buffer has null terminator, need to remove it before
+             // send the DER data to crypto API for reading.
+             if (sgx_endorsements->items[i].data[der_data_size - 1] == 0)
+                 der_data_size -= 1;
+
++            // If the CRL is only composed of hex digits we need to manually convert to DER
++            bool ishex = true;
++            for (size_t l = 0; l < der_data_size; ++l)
++            {
++                uint8_t c = sgx_endorsements->items[i].data[l];
++                if (!((c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f') || (c >= '0' && c <= '9')))
++                {
++                    ishex = false;
++                    break;
++                }
++            }
++            if (ishex)
++            {
++                char *tmp = (char*)oe_malloc(der_data_size);
++                memcpy(tmp, sgx_endorsements->items[i].data, der_data_size);
++                OE_CHECK_MSG(
++                    oe_hex_to_buf(
++                        tmp, der_data_size, sgx_endorsements->items[i].data, der_data_size),
++                    "Failed converting to DER. %s",
++                    oe_result_str(result));
++                der_data_size = der_data_size / 2;
++                oe_free(tmp);
++            }
++
+             OE_CHECK_MSG(
+                 oe_crl_read_der(
+                     &crls[j], sgx_endorsements->items[i].data, der_data_size),
 diff --git a/debugger/gdb-extension/load_symbol_cmd.py b/debugger/gdb-extension/load_symbol_cmd.py
 index ca0e0f893..ea04aa53b 100644
 --- a/debugger/gdb-extension/load_symbol_cmd.py
@@ -1300,6 +1351,43 @@ index 095a16d1e..e152df4c7 100644
  int oe_gethostname(char* name, size_t len);
  
  int oe_getdomainname(char* name, size_t len);
+diff --git a/include/openenclave/internal/utils.h b/include/openenclave/internal/utils.h
+index 82337b74e..8248aef86 100644
+--- a/include/openenclave/internal/utils.h
++++ b/include/openenclave/internal/utils.h
+@@ -228,6 +228,32 @@ OE_INLINE void oe_mem_reverse_inplace(void* mem, size_t n)
+     }
+ }
+
++OE_INLINE unsigned char oe_to_num(char c)
++{
++    if (c >= '0' && c <= '9')
++        return (unsigned char)(c - '0');
++
++    if (c >= 'A' && c <= 'F')
++        return (unsigned char)(10 + (c - 'A'));
++
++    return (unsigned char)(10 + (c - 'a'));
++}
++
++OE_INLINE oe_result_t oe_hex_to_buf(const char* str, size_t strsize, uint8_t* buf, size_t bufsize)
++{
++    if (bufsize * 2 < strsize)
++    {
++        return OE_BUFFER_TOO_SMALL;
++    }
++    for (size_t i = 0; i < strsize; i += 2)
++    {
++        unsigned char v =
++            (unsigned char)(16 * oe_to_num(str[i]) + oe_to_num(str[i + 1]));
++        buf[i / 2] = v;
++    }
++    return OE_OK;
++}
++
+ OE_EXTERNC_END
+
+ #endif /* _OE_UTILS_H */
 diff --git a/libc/malloc.c b/libc/malloc.c
 index 526ae583f..8198d8da0 100644
 --- a/libc/malloc.c


### PR DESCRIPTION
### Proposed changes
API v3 of Intel's PCCS implementation returns CRLs as hex encoded DER. If a hex encoded CRL is encountered during `oe_validate_revocation_list()` we simply convert the hex string to DER.

This allows us to use any PCCS regardless if it correctly returns DER, or hex encoded DER.
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

<!-- (uncomment if applicable)
### Screenshots

-->
