### PR TITLE
sched_getaffinity: get number of cores from host

### DIFF
--- a/src/ert/host/calls.cpp
+++ b/src/ert/host/calls.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <openenclave/internal/trace.h>
+#include <sched.h>
 #include <cassert>
 #include <exception>
 #include "enclave_thread_manager.h"
@@ -45,4 +46,12 @@ int ert_clock_gettime_ocall(
 void ert_exit_ocall(int status)
 {
     exit(status);
+}
+
+size_t ert_getaffinity_cpucount()
+{
+    cpu_set_t cpuset{};
+    if (sched_getaffinity(0, sizeof cpuset, &cpuset) != 0)
+        return 0;
+    return static_cast<size_t>(CPU_COUNT(&cpuset));
 }

--- a/src/ert/include/openenclave/edl/ertlibc.edl
+++ b/src/ert/include/openenclave/edl/ertlibc.edl
@@ -23,6 +23,8 @@ enclave {
 
         void ert_exit_ocall(int status);
 
+        size_t ert_getaffinity_cpucount();
+
         void ert_restart_host_process_ocall();
     };
 }

--- a/src/ertlibc/sched.cpp
+++ b/src/ertlibc/sched.cpp
@@ -1,9 +1,11 @@
 // Copyright (c) Edgeless Systems GmbH.
 // Licensed under the MIT License.
 
+#include <openenclave/internal/globals.h>
 #include <sched.h>
 #include <cerrno>
 #include <system_error>
+#include "ertlibc_t.h"
 #include "syscalls.h"
 
 using namespace std;
@@ -20,12 +22,24 @@ int sc::sched_getaffinity(pid_t pid, size_t size, cpu_set_t* set)
         // getting affinity of other processes not supported
         throw system_error(ENOSYS, system_category(), "sched_getaffinity: pid");
 
+    // Determine ncpu such that it's ideally the number of CPUs in the host
+    // process's affinity mask, but satisfies 2 <= ncpu <= num_tcs - 2
+    // - at least 2 to prevent callers to assume that this is a single-threaded
+    //   process and doesn't need synchronization
+    // - a bit lower than num_tcs to reduce the chance that the caller will
+    //   create too many threads and causes OE_OUT_OF_THREADS
+    static const size_t ncpu = []() -> size_t {
+        const size_t num_tcs = oe_get_num_tcs();
+        size_t count = 0;
+        if (num_tcs <= 4 || ert_getaffinity_cpucount(&count) != OE_OK ||
+            count <= 2)
+            return 2;
+        return min(count, num_tcs - 2);
+    }();
+
     CPU_ZERO_S(size, set);
+    for (size_t i = 0; i < ncpu; ++i)
+        CPU_SET_S(i, size, set);
 
-    // Return at least 2 CPUs so that Go does not assume a single-threaded
-    // process.
-    CPU_SET_S(0, size, set);
-    CPU_SET_S(1, size, set);
-
-    return 1;
+    return min(size, (ncpu + 7) / 8); // number of bytes written
 }


### PR DESCRIPTION
Previously, sched_getaffinity always returned 2 cpus. Now it usually returns the real value.