### PR TITLE
fix crash on terminating a nondebug enclave with lingering threads

### DIFF
--- a/src/ert/host/calls.cpp
+++ b/src/ert/host/calls.cpp
@@ -12,7 +12,12 @@
 using namespace std;
 using namespace ert;
 
-static void _invoke_create_thread_ecall(oe_enclave_t* enclave) noexcept
+// This function is supposed to be run in a new thread created by the
+// EnclaveThreadManager. The thread may be canceled. In the implementation of
+// glibc, the canceled thread throws the internal exception type __forced_unwind
+// to end itself. This exception must not be caught by, e.g., noexcept or
+// catch(...).
+static void _invoke_create_thread_ecall(oe_enclave_t* enclave)
 {
     assert(enclave);
     if (ert_create_thread_ecall(enclave) != OE_OK)

--- a/src/tests/lingering_threads/CMakeLists.txt
+++ b/src/tests/lingering_threads/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_custom_command(
-  OUTPUT test_t.c
+  OUTPUT test_t.c test_u.c
   DEPENDS ../test.edl
-  COMMAND openenclave::oeedger8r --trusted
-          ${CMAKE_CURRENT_SOURCE_DIR}/../test.edl ${DEFINE_OE_SGX})
+  COMMAND openenclave::oeedger8r ${CMAKE_CURRENT_SOURCE_DIR}/../test.edl
+          ${DEFINE_OE_SGX})
 
 add_enclave_library(erttest_lingering_threads_lib OBJECT enc.cpp test_t.c)
+enclave_compile_definitions(erttest_lingering_threads_lib PRIVATE
+                            DEBUG_ENCLAVE=true)
 enclave_include_directories(erttest_lingering_threads_lib PRIVATE
                             ${CMAKE_CURRENT_BINARY_DIR})
 enclave_link_libraries(erttest_lingering_threads_lib PRIVATE oe_includes)
@@ -17,3 +19,37 @@ enclave_link_libraries(erttest_lingering_threads erttest_lingering_threads_lib
 
 add_test(NAME tests/ert/lingering_threads COMMAND erttest_host
                                                   erttest_lingering_threads)
+
+#
+# nondebug test
+#
+# This covers a bug in _invoke_create_thread_ecall() in src/ert/host/calls.cpp that only
+# occurred in nondebug builds. (The stack stitching in OE's __oe_host_stack_bridge() function
+# that is applied to debug enclaves seems to stop the stack unwinding and thus hides the bug.)
+#
+
+add_executable(erttest_lingering_threads_nondebug_host nondebug_host.cpp
+                                                       test_u.c)
+target_include_directories(erttest_lingering_threads_nondebug_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(erttest_lingering_threads_nondebug_host
+                      openenclave::oehost oe_includes)
+
+add_enclave_library(erttest_lingering_threads_nondebug_lib OBJECT enc.cpp
+                    test_t.c)
+enclave_compile_definitions(erttest_lingering_threads_nondebug_lib PRIVATE
+                            DEBUG_ENCLAVE=false)
+enclave_include_directories(erttest_lingering_threads_nondebug_lib PRIVATE
+                            ${CMAKE_CURRENT_BINARY_DIR})
+enclave_link_libraries(erttest_lingering_threads_nondebug_lib PRIVATE
+                       oe_includes)
+set_property(TARGET erttest_lingering_threads_nondebug_lib
+             PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+add_enclave(TARGET erttest_lingering_threads_nondebug SOURCES ../empty.c)
+enclave_link_libraries(erttest_lingering_threads_nondebug
+                       erttest_lingering_threads_nondebug_lib ertlibc)
+
+add_test(tests/ert/lingering_threads_nondebug
+         erttest_lingering_threads_nondebug_host
+         erttest_lingering_threads_nondebug)

--- a/src/tests/lingering_threads/enc.cpp
+++ b/src/tests/lingering_threads/enc.cpp
@@ -40,9 +40,9 @@ void test_ecall()
 }
 
 OE_SET_ENCLAVE_SGX(
-    1,    /* ProductID */
-    1,    /* SecurityVersion */
-    true, /* Debug */
-    64,   /* NumHeapPages */
-    64,   /* NumStackPages */
-    5);   /* NumTCS */
+    1,             /* ProductID */
+    1,             /* SecurityVersion */
+    DEBUG_ENCLAVE, /* Debug */
+    64,            /* NumHeapPages */
+    64,            /* NumStackPages */
+    5);            /* NumTCS */

--- a/src/tests/lingering_threads/nondebug_host.cpp
+++ b/src/tests/lingering_threads/nondebug_host.cpp
@@ -1,0 +1,32 @@
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include <iostream>
+#include "test_u.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2)
+    {
+        cout << "Usage: " << argv[0] << " ENCLAVE\n";
+        return EXIT_FAILURE;
+    }
+
+    oe_enclave_t* enclave = nullptr;
+
+    OE_TEST(
+        oe_create_test_enclave(
+            argv[1],
+            OE_ENCLAVE_TYPE_AUTO,
+            OE_ENCLAVE_FLAG_SIMULATE,
+            nullptr,
+            0,
+            &enclave) == OE_OK);
+    OE_TEST(test_ecall(enclave) == OE_OK);
+    OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+
+    cout << "=== passed all tests (" << argv[0] << ")\n";
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This fixes a crash on exit of a nondebug enclave that has lingering threads (like those of the Go runtime). This has been reported via Discord.

The bug doesn't occur with EGo. I haven't investigated the reason. But that's why we didn't encounter it ourselves yet.