### PR TITLE
update dockerfiles for ubuntu 22.04

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -54,6 +54,7 @@ jobs:
                               "imagename":"edgelessrt-dev",
                               "tag":"nightly",
                               "file": "dockerfiles/Dockerfile",
+                              "args": "--build-arg erttag=master",
                               "target":"release_develop"}}' \
         https://api.github.com/repos/edgelesssys/deployment/dispatches
 
@@ -69,5 +70,6 @@ jobs:
                               "imagename":"edgelessrt-deploy",
                               "tag":"nightly",
                               "file": "dockerfiles/Dockerfile",
+                              "args": "--build-arg erttag=master",
                               "target":"release_deploy"}}' \
         https://api.github.com/repos/edgelesssys/deployment/dispatches

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,76 +1,76 @@
-ARG PSW_VERSION=2.19.100.3-focal1
-ARG DCAP_VERSION=1.16.100.2-focal1
+FROM ghcr.io/edgelesssys/edgelessrt/build-base:v0.4.0 AS build
 
-FROM ubuntu:20.04 AS sgx
-ARG PSW_VERSION
-ARG DCAP_VERSION
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates gnupg wget \
-    && wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add \
-    && echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' >> /etc/apt/sources.list \
-    && wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add \
-    && echo 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod focal main' >> /etc/apt/sources.list \
-    && apt-get update && apt-get install -y --no-install-recommends \
-    az-dcap-client \
-    libsgx-ae-id-enclave=$DCAP_VERSION \
-    libsgx-ae-pce=$PSW_VERSION \
-    libsgx-ae-qe3=$DCAP_VERSION \
-    libsgx-dcap-default-qpl=$DCAP_VERSION \
-    libsgx-dcap-ql=$DCAP_VERSION \
-    libsgx-enclave-common=$PSW_VERSION \
-    libsgx-launch=$PSW_VERSION \
-    libsgx-pce-logic=$DCAP_VERSION \
-    libsgx-qe3-logic=$DCAP_VERSION \
-    libsgx-urts=$PSW_VERSION
-# move the shared libraries installed by libsgx-dcap-default-qpl and remove the package
-# recreating the link /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.1 to /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.intel restores functionality of the original library
-RUN mkdir /usr/lib/x86_64-linux-gnu/dcap && \
-    cp /usr/lib/x86_64-linux-gnu/libsgx_default_qcnl_wrapper.so.1 /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/dcap && \
-    apt remove -y libsgx-dcap-default-qpl && \
-    ln -s /usr/lib/x86_64-linux-gnu/dcap/libsgx_default_qcnl_wrapper.so.1 /usr/lib/x86_64-linux-gnu/libsgx_default_qcnl_wrapper.so.1 && \
-    ln -s /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.1 /usr/lib/x86_64-linux-gnu/dcap/libdcap_quoteprov.so.intel
+# don't run `apt-get update` because required packages are cached in build-base for reproducibility
+RUN apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  clang-11 \
+  cmake \
+  git \
+  libssl-dev \
+  ninja-build \
+  wget
 
-FROM sgx AS base-dev
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    build-essential \
-    cmake \
-    clang-11 \
-    clang-tidy-11 \
-    curl \
-    gdb \
-    git \
-    libssl-dev \
-    nano \
-    ninja-build \
-    pkg-config \
-    vim \
-    zlib1g-dev
-# use same Go version as ertgo
-RUN wget -qO- https://go.dev/dl/go1.20.1.linux-amd64.tar.gz | tar -C /usr/local -xz
+ARG erttag=v0.4.0
+RUN git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
+  && mkdir build
 
-FROM alpine/git:latest AS pull
-RUN git clone --depth=1 https://github.com/edgelesssys/edgelessrt /edgelessrt
-WORKDIR /edgelessrt
-RUN git submodule update --init --depth=1 3rdparty/openenclave/openenclave 3rdparty/go 3rdparty/mystikos/mystikos 3rdparty/ttls
-WORKDIR /edgelessrt/3rdparty/openenclave/openenclave
-RUN git submodule update --init tools/oeedger8r-cpp 3rdparty/mbedtls/mbedtls 3rdparty/musl/musl 3rdparty/musl/libc-test
+RUN cd edgelessrt && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /build \
+  && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF /edgelessrt \
+  && ninja install \
+  && cpack -G DEB \
+  && DEBNAME=$(ls edgelessrt_*_amd64.deb) \
+  && mv $DEBNAME ${DEBNAME%.*}_ubuntu-22.04.deb
 
-FROM base-dev AS build
-COPY --from=pull /edgelessrt /edgelessrt
-WORKDIR /edgelessrt/build
-RUN cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=OFF .. && ninja install
+FROM scratch AS export
+COPY --from=build /build/edgelessrt_*_amd64_ubuntu-22.04.deb /
 
-FROM base-dev as release_develop
+
+FROM ubuntu:jammy-20230605 AS release_deploy
+LABEL description="Containerized SGX for release"
+
+ARG PSW_VERSION=2.19.100.3-jammy1
+ARG DCAP_VERSION=1.16.100.2-jammy1
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
+  && wget -qO /etc/apt/keyrings/intel-sgx-keyring.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
+  && echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' > /etc/apt/sources.list.d/intel-sgx.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
+  libsgx-ae-id-enclave=$DCAP_VERSION \
+  libsgx-ae-pce=$PSW_VERSION \
+  libsgx-ae-qe3=$DCAP_VERSION \
+  libsgx-dcap-default-qpl=$DCAP_VERSION \
+  libsgx-dcap-ql=$DCAP_VERSION \
+  libsgx-enclave-common=$PSW_VERSION \
+  libsgx-launch=$PSW_VERSION \
+  libsgx-pce-logic=$DCAP_VERSION \
+  libsgx-qe3-logic=$DCAP_VERSION \
+  libsgx-urts=$PSW_VERSION
+
+COPY --from=build /opt/edgelessrt/bin/erthost /edgelessrt/dockerfiles/configure-qpl /opt/edgelessrt/bin/
+ENV PATH=$PATH:/opt/edgelessrt/bin
+
+
+FROM release_deploy as release_develop
 LABEL description="EdgelessRT is an SDK to build Trusted Execution Environment applications"
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  clang-11 \
+  clang-tidy-11 \
+  cmake \
+  curl \
+  gdb \
+  git \
+  libssl-dev \
+  nano \
+  ninja-build \
+  pkg-config \
+  vim \
+  zlib1g-dev \
+  # use same Go version as ertgo
+  && wget -qO- https://go.dev/dl/go1.20.1.linux-amd64.tar.gz | tar -C /usr/local -xz
+COPY --from=build /opt/edgelessrt /opt/edgelessrt
 ENV PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/opt/edgelessrt/share/pkgconfig
 ENV CMAKE_PREFIX_PATH=/opt/edgelessrt/lib/openenclave/cmake
 ENV PATH=${PATH}:/opt/edgelessrt/bin:/usr/local/go/bin
 ENV CGO_CFLAGS="$CGO_CFLAGS -I/opt/edgelessrt/include"
 ENV CGO_LDFLAGS="$CGO_LDFLAGS -L/opt/edgelessrt/lib/openenclave/host"
-COPY --from=build /opt/edgelessrt /opt/edgelessrt
-ENTRYPOINT ["bash"]
-
-FROM sgx AS release_deploy
-LABEL description="Containerized SGX for release"
-ENV PATH=${PATH}:/opt/edgelessrt/bin/
-COPY --from=build /opt/edgelessrt/bin/erthost /opt/edgelessrt/bin/erthost
-ENTRYPOINT ["bash"]

--- a/dockerfiles/Dockerfile.build-base-focal
+++ b/dockerfiles/Dockerfile.build-base-focal
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20230605
+FROM ubuntu:focal-20230605
 RUN apt-get update && apt-get install -dy --no-install-recommends \
   build-essential \
   ca-certificates \

--- a/dockerfiles/Dockerfile.focal
+++ b/dockerfiles/Dockerfile.focal
@@ -1,4 +1,4 @@
-FROM ghcr.io/edgelesssys/edgelessrt/build-base:v0.3.9 AS build
+FROM ghcr.io/edgelesssys/edgelessrt/build-base-focal:v0.4.0 AS build
 
 # don't run `apt-get update` because required packages are cached in build-base for reproducibility
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -11,15 +11,17 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   ninja-build \
   wget
 
-ARG erttag=v0.3.9
+ARG erttag=v0.4.0
 RUN git clone -b $erttag --depth=1 https://github.com/edgelesssys/edgelessrt \
   && mkdir build
 
 RUN cd edgelessrt && export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) && cd /build \
   && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF /edgelessrt \
-  && ninja && cpack -G DEB \
+  && ninja \
+  && cpack -G DEB \
+  && DEBNAME=$(ls edgelessrt_*_amd64.deb) \
   # the md5sums file is randomly sorted, which affects the hash of the package. To achieve reproducible build, we have to unpack the package, sort md5sums (in any consistent way) and pack it again.
-  && mkdir tmp && dpkg-deb -R edgelessrt_*_amd64.deb tmp && sort tmp/DEBIAN/md5sums >tmp/DEBIAN/md5sums && dpkg-deb -b tmp edgelessrt_*_amd64.deb
+  && mkdir tmp && dpkg-deb -R $DEBNAME tmp && sort tmp/DEBIAN/md5sums >tmp/DEBIAN/md5sums && dpkg-deb -b tmp ${DEBNAME%.*}_ubuntu-20.04.deb
 
 FROM scratch AS export
-COPY --from=build /build/edgelessrt_*_amd64.deb /
+COPY --from=build /build/edgelessrt_*_amd64_ubuntu-20.04.deb /

--- a/dockerfiles/configure-qpl
+++ b/dockerfiles/configure-qpl
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+if [ -n "${PCCS_ADDR}" ]; then
+	PCCS_URL=https://${PCCS_ADDR}/sgx/certification/v4/
+fi
+
+# if PCCS_URL isn't set and we're on Azure, use Azure PCCS
+if [ -z "${PCCS_URL}" ] && [ "$(cat /sys/devices/virtual/dmi/id/chassis_asset_tag)" = 7783-7084-3265-9085-8269-3286-77 ]; then
+	PCCS_URL=https://global.acccache.azure.net/sgx/certification/v4/
+	if [ -z "${PCCS_USE_SECURE_CERT}" ]; then
+		PCCS_USE_SECURE_CERT=true
+	fi
+fi
+
+if [ -z "${PCCS_USE_SECURE_CERT}" ]; then
+	PCCS_USE_SECURE_CERT=false
+fi
+
+echo "PCCS_URL: ${PCCS_URL}"
+echo "PCCS_USE_SECURE_CERT: ${PCCS_USE_SECURE_CERT}"
+
+if [ "${PCCS_USE_SECURE_CERT}" != true ] && [ "${PCCS_USE_SECURE_CERT}" != false ] ; then
+	echo 'PCCS_USE_SECURE_CERT must be "true" or "false"'
+	exit 1
+fi
+
+sed -i "s/\"use_secure_cert\":.*/\"use_secure_cert\": ${PCCS_USE_SECURE_CERT}/" /etc/sgx_default_qcnl.conf
+if [ -n "${PCCS_URL}" ]; then
+	sed -i "s|\"pccs_url\":.*|\"pccs_url\": \"${PCCS_URL}\"|" /etc/sgx_default_qcnl.conf
+fi


### PR DESCRIPTION
This updates the dockerfiles for reproducibly building DEBs for 20.04 and 22.04, and for edgelessrt-dev and edgelessrt-deploy.

Previously:
* `Dockerfile.build` for building the DEB for 20.04
* `Dockerfile` for edgelessrt-dev and -deploy, not reproducible

Now:
* `Dockerfile.focal` for building the DEB for 20.04 (mostly the same as previous `Dockerfile.build` but gives the DEB a new name)
* `Dockerfile` for building the DEB for 22.04 as well as edgelessrt-dev and -deploy, which contain the reproducible binaries now

Changes for edgelessrt-dev and -deploy:
* based on 22.04
* `libsgx-dcap-default-qpl` only: `az-dcap-client` doesn't support 22.04, but I wanted to get rid of it anyway since Azure PCCS supports the Intel QPL protocol for a while now
* `configure-qpl` command that configures the QPL based on env vars, or automatically for Azure