### PR TITLE
fix crash on enclave termination on Ubuntu 22.04

### DIFF
--- a/3rdparty/openenclave/ert.patch
+++ b/3rdparty/openenclave/ert.patch
@@ -600,7 +600,7 @@ index e3255a942..77351b2ac 100644
      if (!(fds = calloc(nfds, sizeof(struct oe_pollfd))))
      {
 diff --git a/host/sgx/calls.c b/host/sgx/calls.c
-index eed0c4dcf..fb791663e 100644
+index eed0c4dcf..7874c3585 100644
 --- a/host/sgx/calls.c
 +++ b/host/sgx/calls.c
 @@ -36,6 +36,8 @@
@@ -621,7 +621,19 @@ index eed0c4dcf..fb791663e 100644
      OE_CHECK(oe_safe_add_u64(
          args_ptr->input_buffer_size,
          args_ptr->output_buffer_size,
-@@ -365,22 +369,27 @@ static oe_result_t _handle_ocall(
+@@ -358,6 +362,11 @@ static oe_result_t _handle_ocall(
+         func == OE_OCALL_CALL_HOST_FUNCTION ? "EDL_OCALL" : "OE_OCALL",
+         oe_ocall_str(func));
+ 
++    // EDG: During an ocall, allow cancelation by the EnclaveThreadManager
++    // because this thread may block in a syscall.
++    void ert_set_cancelable(bool);
++    ert_set_cancelable(true);
++
+     switch ((oe_func_t)func)
+     {
+         case OE_OCALL_CALL_HOST_FUNCTION:
+@@ -365,22 +374,27 @@ static oe_result_t _handle_ocall(
              break;
  
          case OE_OCALL_MALLOC:
@@ -649,13 +661,14 @@ index eed0c4dcf..fb791663e 100644
              oe_handle_get_time(arg_in, arg_out);
              break;
  
-@@ -391,6 +400,10 @@ static oe_result_t _handle_ocall(
+@@ -391,6 +405,11 @@ static oe_result_t _handle_ocall(
          }
      }
  
-+    // EDG: Insert cancellation point after ocall (esp. after THREAD_WAIT) so
-+    // that EnclaveThreadManager is able to cancel enclave threads.
-+    pthread_testcancel();
++    // EDG: Disable cancelation before returning from ocall because the thread
++    // context will be swapped to the enclave values and canceling would cause a
++    // segfault then.
++    ert_set_cancelable(false);
 +
      result = OE_OK;
  

--- a/src/ert/host/enclave_thread_manager.h
+++ b/src/ert/host/enclave_thread_manager.h
@@ -44,6 +44,5 @@ class EnclaveThreadManager final
 
     std::map<const oe_enclave_t*, std::list<Thread>> threads_;
     std::mutex mutex_;
-    std::atomic<bool> exit_ = false;
 };
 } // namespace ert::host

--- a/src/ert/host/enclave_thread_manager.h
+++ b/src/ert/host/enclave_thread_manager.h
@@ -25,6 +25,11 @@ class EnclaveThreadManager final
     // *func*.
     void create_thread(oe_enclave_t* enclave, void (*func)(oe_enclave_t*));
 
+    // Sets whether it's allowed to call pthread_cancel on the current thread.
+    // This is also a cancelation point (irrespective of the value of
+    // *cancelable*).
+    void set_cancelable(bool cancelable);
+
     // Joins all threads that have been created with create_thread() for
     // *enclave*.
     void join_all_threads(const oe_enclave_t* enclave);
@@ -36,11 +41,20 @@ class EnclaveThreadManager final
   private:
     EnclaveThreadManager() = default;
 
+    enum : unsigned int
+    {
+        Cancelable = 1 << 0,
+        Canceling = 1 << 1,
+    };
+
     struct Thread
     {
         std::thread thread;
         std::atomic<bool> finished;
+        std::atomic<unsigned int> cancel_state;
     };
+
+    static thread_local Thread* self;
 
     std::map<const oe_enclave_t*, std::list<Thread>> threads_;
     std::mutex mutex_;

--- a/src/ert/host/thread.cpp
+++ b/src/ert/host/thread.cpp
@@ -12,6 +12,18 @@
 using namespace std;
 using namespace ert;
 
+extern "C" void ert_set_cancelable(bool cancelable)
+{
+    try
+    {
+        host::EnclaveThreadManager::get_instance().set_cancelable(cancelable);
+    }
+    catch (const exception& e)
+    {
+        OE_TRACE_ERROR("%s", e.what());
+    }
+}
+
 extern "C" oe_result_t ert_join_threads_created_inside_enclave(
     oe_enclave_t* enclave)
 {

--- a/src/tests/lingering_threads/CMakeLists.txt
+++ b/src/tests/lingering_threads/CMakeLists.txt
@@ -1,8 +1,14 @@
 add_custom_command(
   OUTPUT test_t.c test_u.c
   DEPENDS ../test.edl
-  COMMAND openenclave::oeedger8r ${CMAKE_CURRENT_SOURCE_DIR}/../test.edl
+  COMMAND openenclave::oeedger8r ${CMAKE_CURRENT_SOURCE_DIR}/test.edl
           ${DEFINE_OE_SGX})
+
+add_executable(erttest_lingering_threads_host host.cpp test_u.c)
+target_include_directories(erttest_lingering_threads_host
+                           PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(erttest_lingering_threads_host openenclave::oehost
+                      oe_includes)
 
 add_enclave_library(erttest_lingering_threads_lib OBJECT enc.cpp test_t.c)
 enclave_compile_definitions(erttest_lingering_threads_lib PRIVATE
@@ -17,7 +23,7 @@ add_enclave(TARGET erttest_lingering_threads SOURCES ../empty.c)
 enclave_link_libraries(erttest_lingering_threads erttest_lingering_threads_lib
                        ertlibc)
 
-add_test(NAME tests/ert/lingering_threads COMMAND erttest_host
+add_test(NAME tests/ert/lingering_threads COMMAND erttest_lingering_threads_host
                                                   erttest_lingering_threads)
 
 #

--- a/src/tests/lingering_threads/enc.cpp
+++ b/src/tests/lingering_threads/enc.cpp
@@ -33,10 +33,15 @@ void test_ecall()
 
     thread([] {}).detach();
 
-    this_thread::sleep_for(100ms);
+    this_thread::sleep_for(10ms);
 
     // The actual test happens when the host calls oe_terminate_enclave().
     // Threads are expected to be successfully canceled.
+}
+
+void test_child_of_child_ecall()
+{
+    thread([] { thread([] {}).detach(); }).detach();
 }
 
 OE_SET_ENCLAVE_SGX(

--- a/src/tests/lingering_threads/host.cpp
+++ b/src/tests/lingering_threads/host.cpp
@@ -1,0 +1,51 @@
+#include <openenclave/host.h>
+#include <openenclave/internal/tests.h>
+#include <iostream>
+#include "test_u.h"
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2)
+    {
+        cout << "Usage: " << argv[0] << " ENCLAVE\n";
+        return EXIT_FAILURE;
+    }
+
+    const char* const enclave_image = argv[1];
+    const uint32_t flags = oe_get_create_flags();
+    oe_enclave_t* enclave = nullptr;
+
+    for (int i = 0; i < 100; ++i)
+    {
+        OE_TEST(
+            oe_create_test_enclave(
+                enclave_image,
+                OE_ENCLAVE_TYPE_AUTO,
+                flags,
+                nullptr,
+                0,
+                &enclave) == OE_OK);
+        OE_TEST(test_ecall(enclave) == OE_OK);
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    }
+
+    for (int i = 0; i < 100; ++i)
+    {
+        OE_TEST(
+            oe_create_test_enclave(
+                enclave_image,
+                OE_ENCLAVE_TYPE_AUTO,
+                flags,
+                nullptr,
+                0,
+                &enclave) == OE_OK);
+        OE_TEST(test_child_of_child_ecall(enclave) == OE_OK);
+        OE_TEST(oe_terminate_enclave(enclave) == OE_OK);
+    }
+
+    cout << "=== passed all tests (" << enclave_image << ")\n";
+
+    return EXIT_SUCCESS;
+}

--- a/src/tests/lingering_threads/test.edl
+++ b/src/tests/lingering_threads/test.edl
@@ -1,0 +1,15 @@
+enclave {
+    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/syscall.edl" import *;
+#ifdef OE_SGX
+    from "openenclave/edl/sgx/platform.edl" import *;
+#else
+    from "openenclave/edl/optee/platform.edl" import *;
+#endif
+    from "openenclave/edl/ertlibc.edl" import *;
+
+    trusted {
+        public void test_ecall();
+        public void test_child_of_child_ecall();
+    };
+};


### PR DESCRIPTION
glibc >= 2.34 has a new implementation of `pthread_cancel`. It now always uses the `fs` register. (Previously, it did so only in situations not affecting us.) OE swaps `fs` when entering the enclave in simulation mode. If a thread is then canceled, it causes a segfault.

To fix this, only call `pthread_cancel` when the target thread is in an ocall. Let the target thread check for a cancelation request while it was inside the enclave.

Changes (I suggest looking at corresponding commits separately)
* Properly fix a deadlock in `cancel_all_threads`. The previous fix left a small window where a deadlock can still happen. More importantly, it prevented creating threads in a new enclave if a previous enclave had been terminated.
* Improve the test to catch the bugs.
* Fix the bug by adding `set_cancelable` to `EnclaveThreadManager`.