### PR TITLE
clock_getres

### DIFF
--- a/src/ertlibc/syscall.cpp
+++ b/src/ertlibc/syscall.cpp
@@ -39,6 +39,8 @@ long ert_syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
             case SYS_clock_gettime:
                 return sc::clock_gettime(
                     static_cast<int>(x1), reinterpret_cast<timespec*>(x2));
+            case SYS_clock_getres:
+                return sc::clock_getres(x1, reinterpret_cast<timespec*>(x2));
             case SYS_gettid:
                 return ert_thread_self()->tid;
 

--- a/src/ertlibc/syscalls.h
+++ b/src/ertlibc/syscalls.h
@@ -15,6 +15,7 @@ struct k_sigaction;
 namespace ert::sc
 {
 int clock_gettime(clockid_t clk_id, struct timespec* tp);
+int clock_getres(clockid_t clk_id, struct timespec* tp);
 void exit_group(int status);
 int fstatfs(int fd, struct statfs* buf);
 int prlimit(

--- a/src/ertlibc/time.cpp
+++ b/src/ertlibc/time.cpp
@@ -162,3 +162,14 @@ int sc::clock_gettime(int clk_id, struct timespec* tp)
 
     return 0;
 }
+
+int sc::clock_getres(int /*clk_id*/, struct timespec* tp)
+{
+    if (tp)
+    {
+        // only coarse resolution is supported
+        tp->tv_sec = 0;
+        tp->tv_nsec = 4'000'000;
+    }
+    return 0;
+}

--- a/src/tests/misc_syscalls/enc.cpp
+++ b/src/tests/misc_syscalls/enc.cpp
@@ -225,6 +225,13 @@ static void _test_syconf()
 static void _test_time()
 {
     {
+        OE_TEST(clock_getres(CLOCK_MONOTONIC, nullptr) == 0);
+        timespec t{};
+        OE_TEST(clock_getres(CLOCK_MONOTONIC, &t) == 0);
+        OE_TEST(t.tv_sec == 0);
+        OE_TEST(t.tv_nsec == 4'000'000);
+    }
+    {
         timespec t1{};
         timespec t2{};
         OE_TEST(clock_gettime(CLOCK_MONOTONIC, &t1) == 0);


### PR DESCRIPTION
add clock_getres syscall, which is needed for EGo's wasmtime sample