### PR TITLE
move __res_init to syscall.cpp so that it's always included in ertlibc

### DIFF
--- a/src/ertlibc/stubs.cpp
+++ b/src/ertlibc/stubs.cpp
@@ -8,8 +8,3 @@ void ert_stub_trace(const char* msg)
 {
     OE_TRACE_ERROR("not implemented: %s", msg);
 }
-
-extern "C" int __res_init()
-{
-    return 0; // success
-}

--- a/src/ertlibc/syscall.cpp
+++ b/src/ertlibc/syscall.cpp
@@ -241,6 +241,11 @@ extern "C" locale_t __newlocale(int mask, const char* locale, locale_t loc)
     return const_cast<locale_t>(&c_locale);
 }
 
+extern "C" int __res_init()
+{
+    return 0; // success
+}
+
 // The debug malloc check runs on enclave termination and prints errors for heap
 // memory that has not been freed. As some global objects in (std)c++ use heap
 // memory and don't free it by design, we cannot use this feature.

--- a/src/tests/payload_image/payload.c
+++ b/src/tests/payload_image/payload.c
@@ -4,6 +4,11 @@
 int main()
 {
     puts("hello from payload");
+
+    // test that ertlibc contains this symbol
+    void __res_init();
+    __res_init();
+
     return 2;
 }
 


### PR DESCRIPTION
The __res_init stub is required by some cgo code. As EGo doesn't use any symbol of stubs.cpp, stubs.o won't be linked into EGo's libc. Move __res_init to syscall.cpp so that it's always included and available for EGo apps that dynamically link it.