### PR TITLE
support vDSO clock for kernel >= v6.10

### DIFF
--- a/src/ert/host/vdso.cpp
+++ b/src/ert/host/vdso.cpp
@@ -16,12 +16,27 @@
 
 using namespace std;
 
-// from Linux kernel include/vdso/datapage.h
+// from Linux kernel include/vdso/datapage.h, kernel < v6.10
 struct vdso_data
 {
     uint32_t seq; // timebase sequence counter
     uint32_t clock_mode;
     uint64_t cycle_last;
+    uint64_t mask;
+    uint64_t reserved0;
+
+    oe_vdso_timestamp_t reserved1[5];
+    oe_vdso_timestamp_t realtime_coarse;
+    oe_vdso_timestamp_t monotonic_coarse;
+};
+
+// from Linux kernel include/vdso/datapage.h, kernel >= v6.10
+struct vdso_data_new
+{
+    uint32_t seq; // timebase sequence counter
+    uint32_t clock_mode;
+    uint64_t cycle_last;
+    uint64_t max_cycles; // new in v6.10 if CONFIG_GENERIC_VDSO_OVERFLOW_PROTECT
     uint64_t mask;
     uint64_t reserved0;
 
@@ -61,15 +76,35 @@ static void _get_clock_vdso_pointers(
 {
     const auto vdsodata =
         reinterpret_cast<vdso_data*>(_get_vvar() + _vvar_vdso_data_offset);
-
-    // TODO This heuristic check is not guaranteed to catch the error. There
-    // could be (future) kernels that have some other data at these offsets.
-    if (!vdsodata->realtime_coarse.sec || !vdsodata->monotonic_coarse.sec)
-        throw runtime_error("kernel doesn't provide vDSO clock");
-
     seq = &vdsodata->seq;
-    clock_realtime_coarse = &vdsodata->realtime_coarse;
-    clock_monotonic_coarse = &vdsodata->monotonic_coarse;
+
+    // get current monotonic time as reference value
+    timespec tp{};
+    if (clock_gettime(CLOCK_MONOTONIC_COARSE, &tp) != 0)
+        throw system_error(errno, system_category(), "clock_gettime");
+
+    // try older vdso_data struct
+    auto sec =
+        __atomic_load_n(&vdsodata->monotonic_coarse.sec, __ATOMIC_SEQ_CST);
+    if (abs(sec - tp.tv_sec) <= 1)
+    {
+        clock_realtime_coarse = &vdsodata->realtime_coarse;
+        clock_monotonic_coarse = &vdsodata->monotonic_coarse;
+        return;
+    }
+
+    // try newer vdso_data struct
+    const auto vdsodata_new = reinterpret_cast<vdso_data_new*>(vdsodata);
+    sec =
+        __atomic_load_n(&vdsodata_new->monotonic_coarse.sec, __ATOMIC_SEQ_CST);
+    if (abs(sec - tp.tv_sec) <= 1)
+    {
+        clock_realtime_coarse = &vdsodata_new->realtime_coarse;
+        clock_monotonic_coarse = &vdsodata_new->monotonic_coarse;
+        return;
+    }
+
+    throw runtime_error("kernel doesn't provide vDSO clock");
 }
 
 extern "C" oe_result_t oe_get_clock_vdso_pointers_ocall(


### PR DESCRIPTION
`vdso_data` struct changed with kernel v6.10. Check both old and new memory location of monotonic time and compare that with the result of `clock_gettime` to decide which memory location to use.