### PR TITLE
explicitly flush logs

### DIFF
--- a/src/tools/erthost/erthost.cpp
+++ b/src/tools/erthost/erthost.cpp
@@ -223,7 +223,7 @@ static void _log(
 
     _trim_space(msg);
     cout << level_string << ": " << msg << " [" << path << ':' << func_and_line
-         << "]\n";
+         << ']' << endl;
 }
 
 int main(int argc, char* argv[], char* envp[])


### PR DESCRIPTION
ERT (as well as OE) uses stdout for logs. When running without tty (e.g., default in K8s), block buffering is used and log messages may be printed delayed or not at all. Explicitly flush after each log message to fix this.