### PR TITLE
zero memory on MADV_DONTNEED

### DIFF
--- a/src/ert/libc/mman.c
+++ b/src/ert/libc/mman.c
@@ -19,6 +19,8 @@ malloc calls mmap to reserve enclave heap space.
 #include <string.h>
 #include "../common/bitset.h"
 
+#define MADV_DONTNEED 4
+
 static oe_spinlock_t _lock = OE_SPINLOCK_INITIALIZER;
 static void* _bitset;
 static void* _base;
@@ -132,6 +134,28 @@ int ert_munmap(void* addr, size_t length)
         (uintptr_t)addr % OE_PAGE_SIZE == 0)
     {
         ert_bitset_reset_range(_bitset, _to_pos(addr), length / OE_PAGE_SIZE);
+        result = 0;
+    }
+
+    oe_spin_unlock(&_lock);
+
+    return result;
+}
+
+int ert_madvise(void* addr, size_t length, int advice)
+{
+    if ((uintptr_t)addr % OE_PAGE_SIZE)
+        return -EINVAL;
+    if (!length || advice != MADV_DONTNEED)
+        return 0;
+    int result = -ENOMEM;
+    length = oe_round_up_to_page_size(length);
+
+    oe_spin_lock(&_lock);
+
+    if (_length_in_range(length) && _addr_in_range(addr, length))
+    {
+        memset(addr, 0, length);
         result = 0;
     }
 

--- a/src/ert/libc/mman.h
+++ b/src/ert/libc/mman.h
@@ -14,3 +14,5 @@ void* ert_mmap(
     off_t offset);
 
 int ert_munmap(void* addr, size_t length);
+
+int ert_madvise(void* addr, size_t length, int advice);

--- a/src/ert/libc/syscalls.c
+++ b/src/ert/libc/syscalls.c
@@ -43,6 +43,8 @@ long __syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
             return (long)ert_mmap((void*)x1, x2, x3, x4, x5, x6);
         case OE_SYS_munmap:
             return ert_munmap((void*)x1, x2);
+        case OE_SYS_madvise:
+            return ert_madvise((void*)x1, x2, x3);
     }
 
     // Try hook

--- a/src/ertlibc/syscall.cpp
+++ b/src/ertlibc/syscall.cpp
@@ -89,7 +89,6 @@ long ert_syscall(long n, long x1, long x2, long x3, long x4, long x5, long x6)
                     reinterpret_cast<cpu_set_t*>(x3));
 
             case SYS_mprotect:
-            case SYS_madvise:
             case SYS_mlock:
             case SYS_munlock:
             case SYS_mlockall:

--- a/src/tests/mman/enc.cpp
+++ b/src/tests/mman/enc.cpp
@@ -2,6 +2,7 @@
 #include <openenclave/internal/tests.h>
 #include <sys/mman.h>
 #include <algorithm>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include "test_t.h"
@@ -54,6 +55,25 @@ void test_ecall()
     _test_filled(p, OE_PAGE_SIZE, 2);
     _test_filled(p + OE_PAGE_SIZE, OE_PAGE_SIZE, 0);
     _test_filled(p + 2 * OE_PAGE_SIZE, OE_PAGE_SIZE, 2);
+
+    // test madvise
+    OE_TEST(madvise(nullptr, 0, MADV_NORMAL) == 0);
+    OE_TEST(madvise(p, 0, MADV_NORMAL) == 0);
+    _test_filled(p, OE_PAGE_SIZE, 2);
+    OE_TEST(madvise(p, 1, MADV_NORMAL) == 0);
+    _test_filled(p, OE_PAGE_SIZE, 2);
+    OE_TEST(madvise(p, 0, MADV_DONTNEED) == 0);
+    _test_filled(p, OE_PAGE_SIZE, 2);
+    OE_TEST(madvise(p, 1, MADV_DONTNEED) == 0);
+    _test_filled(p, OE_PAGE_SIZE, 0);
+
+    // test madvise invalid args
+    OE_TEST(madvise(p + 1, 0, MADV_NORMAL) == -1);
+    OE_TEST(errno == EINVAL);
+    OE_TEST(madvise(p + 1, 1, MADV_NORMAL) == -1);
+    OE_TEST(errno == EINVAL);
+    OE_TEST(madvise(nullptr, 1, MADV_DONTNEED) == -1);
+    OE_TEST(errno == ENOMEM);
 
     // mmap did not overwrite heap allocation. (Ensures that malloc uses mmap
     // internally instead of directly using the enclave heap memory.)


### PR DESCRIPTION
Go 1.26 expects memory returned to the kernel via MADV_DONTNEED to be zero-filled on its next use.